### PR TITLE
:sparkles: Add teams related commands

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -19,6 +19,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/users.c 								\
 					src/commands/send.c 								\
 					src/commands/messages.c 							\
+					src/commands/subscribe.c 							\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -20,6 +20,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/send.c 								\
 					src/commands/messages.c 							\
 					src/commands/subscribe.c 							\
+					src/commands/subscribed.c 							\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -21,6 +21,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/messages.c 							\
 					src/commands/subscribe.c 							\
 					src/commands/subscribed.c 							\
+					src/commands/unsubscribe.c 							\
 					src/utils/utils.c 									\
 
 

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -51,6 +51,7 @@ void on_command(char *cmd, client_t *client);
 char **parse_command(char *cmd);
 
 size_t tab_len(char **tab);
+char *add_bearer(char *uuid);
 
 
 void help(char **parsed_cmd);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -63,3 +63,4 @@ void cmd_send(char **parsed_cmd, client_t *client);
 void messages(char **parsed_cmd, client_t *client);
 void subscribe(char **parsed_cmd, client_t *client);
 void subscribed(char **parsed_cmd, client_t *client);
+void unsubscribe(char **parsed_cmd, client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -61,3 +61,4 @@ void user(char **parsed_cmd, client_t *client);
 void users(char **parsed_cmd, client_t *client);
 void cmd_send(char **parsed_cmd, client_t *client);
 void messages(char **parsed_cmd, client_t *client);
+void subscribe(char **parsed_cmd, client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -62,3 +62,4 @@ void users(char **parsed_cmd, client_t *client);
 void cmd_send(char **parsed_cmd, client_t *client);
 void messages(char **parsed_cmd, client_t *client);
 void subscribe(char **parsed_cmd, client_t *client);
+void subscribed(char **parsed_cmd, client_t *client);

--- a/client/src/commands/logout.c
+++ b/client/src/commands/logout.c
@@ -12,8 +12,6 @@
 void logout_rep(response_t *response, request_data_t *request_data)
 {
     client_t *cli = (client_t *)request_data->data;
-    json_object_t *jobj = NULL;
-    json_string_t *str = NULL;
 
     cli->waiting_for_response = false;
     if (response->status == 204) {
@@ -26,17 +24,16 @@ void logout_rep(response_t *response, request_data_t *request_data)
 
 static void request_logout(client_t *client)
 {
-    json_object_t *jobj = json_object_create("root");
-    json_string_t *uuid = json_string_create("user_uuid", client->user_uuid);
+    char *uuid = add_bearer(client->user_uuid);
     request_t *request = calloc(1, sizeof(request_t));
 
-    if (jobj == NULL || uuid == NULL || request == NULL) {
+    if (uuid == NULL || request == NULL) {
         printf("Error: malloc failed\n");
         return;
     }
-    json_object_add(jobj, (json_t *)uuid);
     request->route = (route_t){"POST", "/logout"};
-    request->body = json_serialize((json_t *)jobj);
+    request_add_header(request, "Authorization", uuid);
+    request->body = strdup("");
     api_client_send_request(client->api_handler, request, &logout_rep, client);
     client->waiting_for_response = true;
 }

--- a/client/src/commands/messages.c
+++ b/client/src/commands/messages.c
@@ -53,16 +53,15 @@ void messages_response(response_t *response, request_data_t *request_data)
 
 static void send_messages(client_t *client, char *user_uuid)
 {
-    json_object_t *jobj = json_object_create("root");
-    json_string_t *user = json_string_create("user_uuid", client->user_uuid);
+    char *bearer = add_bearer(client->user_uuid);
     request_t *request = calloc(1, sizeof(request_t));
 
-    if (jobj == NULL || user == NULL || request == NULL)
+    if (bearer == NULL || request == NULL)
         return;
-    json_object_add(jobj, (json_t *)user);
     request->route = (route_t){"GET", "/messages"};
-    request->body = json_serialize((json_t *)jobj);
     request_add_param(request, "uuid", user_uuid);
+    request_add_header(request, "Authorization", bearer);
+    request->body = strdup("");
     api_client_send_request(client->api_handler, request, &messages_response,
         client);
     client->waiting_for_response = true;

--- a/client/src/commands/on_command.c
+++ b/client/src/commands/on_command.c
@@ -13,6 +13,8 @@ void on_command_2(char **parsed_cmd, client_t *client)
         return subscribe(parsed_cmd, client);
     if (strcmp(parsed_cmd[0], "/subscribed") == 0)
         return subscribed(parsed_cmd, client);
+    if (strcmp(parsed_cmd[0], "/unsubscribe") == 0)
+        return unsubscribe(parsed_cmd, client);
     printf("Unknown command\n");
 }
 

--- a/client/src/commands/on_command.c
+++ b/client/src/commands/on_command.c
@@ -9,6 +9,8 @@
 
 void on_command_2(char **parsed_cmd, client_t *client)
 {
+    if (strcmp(parsed_cmd[0], "/subscribe") == 0)
+        return subscribe(parsed_cmd, client);
     printf("Unknown command\n");
 }
 

--- a/client/src/commands/on_command.c
+++ b/client/src/commands/on_command.c
@@ -11,6 +11,8 @@ void on_command_2(char **parsed_cmd, client_t *client)
 {
     if (strcmp(parsed_cmd[0], "/subscribe") == 0)
         return subscribe(parsed_cmd, client);
+    if (strcmp(parsed_cmd[0], "/subscribed") == 0)
+        return subscribed(parsed_cmd, client);
     printf("Unknown command\n");
 }
 

--- a/client/src/commands/send.c
+++ b/client/src/commands/send.c
@@ -35,21 +35,21 @@ void send_response(response_t *response, request_data_t *request_data)
 static void send_send(client_t *client, char *user_uuid, char *message_body)
 {
     json_object_t *jobj = json_object_create("root");
-    json_string_t *user = json_string_create("user_uuid", client->user_uuid);
     json_string_t *recipient = json_string_create("recipient_uuid", user_uuid);
     json_string_t *body = json_string_create("content", message_body);
     json_object_t *message = json_object_create("message");
     request_t *request = calloc(1, sizeof(request_t));
+    char *bearer = add_bearer(client->user_uuid);
 
-    if (jobj == NULL || user == NULL || request == NULL || recipient == NULL ||
-        body == NULL || message == NULL)
+    if (jobj == NULL || request == NULL || recipient == NULL ||
+        body == NULL || message == NULL || bearer == NULL)
         return;
     json_object_add(message, (json_t *)body);
-    json_object_add(jobj, (json_t *)user);
     json_object_add(jobj, (json_t *)recipient);
     json_object_add(jobj, (json_t *)message);
     request->route = (route_t){"POST", "/messages/send"};
     request->body = json_serialize((json_t *)jobj);
+    request_add_header(request, "Authorization", bearer);
     api_client_send_request(client->api_handler, request, &send_response,
         client);
     client->waiting_for_response = true;

--- a/client/src/commands/subscribe.c
+++ b/client/src/commands/subscribe.c
@@ -1,0 +1,72 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** subscribe
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+#include "json/json.h"
+
+void subscribe_response(response_t *response, request_data_t *request_data)
+{
+    client_t *cli = (client_t *)request_data->data;
+    json_object_t *jobj = NULL;
+    json_string_t *team_uuid = NULL;
+
+    cli->waiting_for_response = false;
+    if (response->status == 204) {
+        jobj = (json_object_t *)json_parse(request_data->req->body);
+        team_uuid = (json_string_t *)json_object_get(jobj, "team_uuid");
+        if (team_uuid == NULL)
+            return;
+        client_print_subscribed(cli->user_uuid, team_uuid->value);
+    }
+    if (response->status == 404) {
+        jobj = (json_object_t *)json_parse(request_data->req->body);
+        team_uuid = (json_string_t *)json_object_get(jobj, "team_uuid");
+        if (team_uuid == NULL)
+            return;
+        client_error_unknown_team(team_uuid->value);
+    }
+}
+
+static void send_subscribe(client_t *client, char *team_uuid)
+{
+    request_t *request = calloc(1, sizeof(request_t));
+    json_object_t *jobj = json_object_create("root");
+    json_string_t *uuid = json_string_create("team_uuid", team_uuid);
+    char *bearer = add_bearer(client->user_uuid);
+
+    if (bearer == NULL || request == NULL || jobj == NULL || uuid == NULL) {
+        printf("Error: malloc failed\n");
+        return;
+    }
+    json_object_add(jobj, (json_t *)uuid);
+    request->route = (route_t){"POST", "/teams/join"};
+    request->body = json_serialize((json_t *)jobj);
+    request_add_header(request, "Authorization", bearer);
+    api_client_send_request(client->api_handler, request, &subscribe_response,
+        client);
+    client->waiting_for_response = true;
+}
+
+void subscribe(char **parsed_cmd, client_t *client)
+{
+    int len = tab_len(parsed_cmd);
+
+    if (len != 2) {
+        printf("Usage: /subscribe [team_uuid]\n");
+        return;
+    }
+    if (uuid_from_string(parsed_cmd[1]) == NULL) {
+        printf("Error: invalid uuid\n");
+        return;
+    }
+    if (client->is_logged == false) {
+        client_error_unauthorized();
+        return;
+    }
+    send_subscribe(client, parsed_cmd[1]);
+}

--- a/client/src/commands/subscribed.c
+++ b/client/src/commands/subscribed.c
@@ -1,0 +1,152 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** subscribed
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+#include "json/json.h"
+
+static void display_teams(json_array_t *arr)
+{
+    int i = 0;
+    json_object_t *team = NULL;
+    json_string_t *t_uuid = NULL;
+    json_string_t *t_name = NULL;
+    json_string_t *t_desc = NULL;
+
+    do {
+        team = (json_object_t *)json_array_get(arr, i);
+        if (team == NULL)
+            return;
+        t_uuid = (json_string_t *)json_object_get(team, "team_uuid");
+        t_name = (json_string_t *)json_object_get(team, "team_name");
+        t_desc = (json_string_t *)json_object_get(team, "team_description");
+        if (t_uuid == NULL || t_name == NULL || t_desc == NULL) {
+            return;
+        }
+        client_print_teams(t_uuid->value, t_name->value, t_desc->value);
+        i++;
+    } while (1);
+}
+
+void subscribed_response(response_t *response, request_data_t *request_data)
+{
+    client_t *cli = (client_t *)request_data->data;
+    json_array_t *arr = NULL;
+
+    cli->waiting_for_response = false;
+    if (response->status == 200) {
+        arr = (json_array_t *)json_array_parse(response->body);
+        if (arr == NULL)
+            return;
+        display_teams(arr);
+    }
+}
+
+static void display_users(json_array_t *arr)
+{
+    int i = 0;
+    json_object_t *user = NULL;
+    json_string_t *uuid = NULL;
+    json_string_t *username = NULL;
+    json_string_t *status = NULL;
+
+    do {
+        user = (json_object_t *)json_array_get(arr, i);
+        if (user == NULL)
+            return;
+        uuid = (json_string_t *)json_object_get(user, "uuid");
+        username = (json_string_t *)json_object_get(user, "username");
+        status = (json_string_t *)json_object_get(user, "status");
+        if (uuid == NULL || username == NULL || status == NULL) {
+            return;
+        }
+        client_print_users(uuid->value, username->value,
+            (status->value[1] == 'N' ? 1 : 0));
+        i++;
+    } while (1);
+}
+
+void users_subscribed_response(response_t *response,
+    request_data_t *request_data)
+{
+    client_t *cli = (client_t *)request_data->data;
+    json_array_t *arr = NULL;
+
+    cli->waiting_for_response = false;
+    if (response->status == 200) {
+        arr = (json_array_t *)json_array_parse(response->body);
+        if (arr == NULL)
+            return;
+        display_users(arr);
+    }
+    if (response->status == 404) {
+        client_error_unknown_team(
+            request_get_param(request_data->req, "team_uuid"));
+    }
+    if (response->status == 403) {
+        client_error_unauthorized();
+    }
+}
+
+static void send_subscribed(client_t *client)
+{
+    request_t *request = calloc(1, sizeof(request_t));
+    char *bearer = add_bearer(client->user_uuid);
+
+    if (bearer == NULL || request == NULL) {
+        printf("Error: malloc failed\n");
+        return;
+    }
+    request->route = (route_t){"GET", "/teams"};
+    request->body = strdup("");
+    request_add_header(request, "Authorization", bearer);
+    request_add_param(request, "only-joined", "true");
+    api_client_send_request(client->api_handler, request, &subscribed_response,
+        client);
+    client->waiting_for_response = true;
+}
+
+static void send_users_subscribed(client_t *client, char *team_uuid)
+{
+    request_t *request = calloc(1, sizeof(request_t));
+    char *bearer = add_bearer(client->user_uuid);
+
+    if (bearer == NULL || request == NULL) {
+        printf("Error: malloc failed\n");
+        return;
+    }
+    request->route = (route_t){"GET", "/teams/users"};
+    request->body = strdup("");
+    request_add_header(request, "Authorization", bearer);
+    request_add_param(request, "team-uuid", team_uuid);
+    api_client_send_request(client->api_handler, request,
+        &users_subscribed_response, client);
+    client->waiting_for_response = true;
+}
+
+void subscribed(char **parsed_cmd, client_t *client)
+{
+    int len = tab_len(parsed_cmd);
+
+    if (len != 1 && len != 2) {
+        printf("Usage: /subscribed ?[team_uuid]\n");
+        return;
+    }
+    if (client->is_logged == false) {
+        client_error_unauthorized();
+        return;
+    }
+    if (len == 1) {
+        send_subscribed(client);
+        return;
+    }
+    if (uuid_from_string(parsed_cmd[1]) == NULL) {
+        printf("Error: invalid uuid\n");
+        return;
+    }
+    send_users_subscribed(client, parsed_cmd[1]);
+}

--- a/client/src/commands/unsubscribe.c
+++ b/client/src/commands/unsubscribe.c
@@ -1,0 +1,84 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** unsubscribe
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+#include "json/json.h"
+
+void unsubscribe_response_error(response_t *response,
+    request_data_t *request_data)
+{
+    client_t *cli = (client_t *)request_data->data;
+    json_object_t *jobj = NULL;
+    json_string_t *team_uuid = NULL;
+
+    if (response->status == 404) {
+        jobj = (json_object_t *)json_parse(request_data->req->body);
+        team_uuid = (json_string_t *)json_object_get(jobj, "team_uuid");
+        if (team_uuid == NULL)
+            return;
+        client_error_unknown_team(team_uuid->value);
+    }
+    if (response->status == 401)
+        client_error_unauthorized();
+}
+
+void unsubscribe_response(response_t *response, request_data_t *request_data)
+{
+    client_t *cli = (client_t *)request_data->data;
+    json_object_t *jobj = NULL;
+    json_string_t *team_uuid = NULL;
+
+    cli->waiting_for_response = false;
+    if (response->status == 204) {
+        jobj = (json_object_t *)json_parse(request_data->req->body);
+        team_uuid = (json_string_t *)json_object_get(jobj, "team_uuid");
+        if (team_uuid == NULL)
+            return;
+        client_print_unsubscribed(cli->user_uuid, team_uuid->value);
+    }
+    unsubscribe_response_error(response, request_data);
+}
+
+static void send_unsubscribe(client_t *client, char *team_uuid)
+{
+    request_t *request = calloc(1, sizeof(request_t));
+    json_object_t *jobj = json_object_create("root");
+    json_string_t *uuid = json_string_create("team_uuid", team_uuid);
+    char *bearer = add_bearer(client->user_uuid);
+
+    if (bearer == NULL || request == NULL || jobj == NULL || uuid == NULL) {
+        printf("Error: malloc failed\n");
+        return;
+    }
+    json_object_add(jobj, (json_t *)uuid);
+    request->route = (route_t){"POST", "/teams/leave"};
+    request->body = json_serialize((json_t *)jobj);
+    request_add_header(request, "Authorization", bearer);
+    api_client_send_request(client->api_handler, request,
+    &unsubscribe_response, client);
+    client->waiting_for_response = true;
+}
+
+void unsubscribe(char **parsed_cmd, client_t *client)
+{
+    int len = tab_len(parsed_cmd);
+
+    if (len != 2) {
+        printf("Usage: /unsubscribe [team_uuid]\n");
+        return;
+    }
+    if (uuid_from_string(parsed_cmd[1]) == NULL) {
+        printf("Error: invalid uuid\n");
+        return;
+    }
+    if (client->is_logged == false) {
+        client_error_unauthorized();
+        return;
+    }
+    send_unsubscribe(client, parsed_cmd[1]);
+}

--- a/client/src/commands/unsubscribe.c
+++ b/client/src/commands/unsubscribe.c
@@ -12,7 +12,6 @@
 void unsubscribe_response_error(response_t *response,
     request_data_t *request_data)
 {
-    client_t *cli = (client_t *)request_data->data;
     json_object_t *jobj = NULL;
     json_string_t *team_uuid = NULL;
 

--- a/client/src/commands/user.c
+++ b/client/src/commands/user.c
@@ -49,16 +49,15 @@ void user_response(response_t *response, request_data_t *request_data)
 
 static void send_user(client_t *client, char *uuid)
 {
-    json_object_t *jobj = json_object_create("root");
-    json_string_t *user = json_string_create("user_uuid", client->user_uuid);
+    char *bearer = add_bearer(client->user_uuid);
     request_t *request = calloc(1, sizeof(request_t));
 
-    if (jobj == NULL || user == NULL || request == NULL)
+    if (bearer == NULL || request == NULL)
         return;
-    json_object_add(jobj, (json_t *)user);
     request->route = (route_t){"GET", "/user"};
-    request->body = json_serialize((json_t *)jobj);
+    request_add_header(request, "Authorization", bearer);
     request_add_param(request, "uuid", uuid);
+    request->body = strdup("");
     api_client_send_request(client->api_handler, request, &user_response,
         client);
     client->waiting_for_response = true;

--- a/client/src/commands/users.c
+++ b/client/src/commands/users.c
@@ -9,7 +9,7 @@
 #include "logging_client.h"
 #include "json/json.h"
 
-void display_users(json_array_t *arr)
+static void display_users(json_array_t *arr)
 {
     int i = 0;
     json_object_t *user = NULL;
@@ -49,17 +49,16 @@ void users_response(response_t *response, request_data_t *request_data)
 
 static void send_users(client_t *client)
 {
-    json_object_t *jobj = json_object_create("root");
-    json_string_t *uuid = json_string_create("user_uuid", client->user_uuid);
     request_t *request = calloc(1, sizeof(request_t));
+    char *uuid = add_bearer(client->user_uuid);
 
-    if (jobj == NULL || uuid == NULL || request == NULL) {
+    if (uuid == NULL || request == NULL) {
         printf("Error: malloc failed\n");
         return;
     }
-    json_object_add(jobj, (json_t *)uuid);
     request->route = (route_t){"GET", "/users"};
-    request->body = json_serialize((json_t *)jobj);
+    request_add_header(request, "Authorization", uuid);
+    request->body = strdup("");
     api_client_send_request(client->api_handler, request, &users_response,
         client);
     client->waiting_for_response = true;

--- a/client/src/utils/utils.c
+++ b/client/src/utils/utils.c
@@ -15,3 +15,14 @@ size_t tab_len(char **tab)
         i++;
     return i;
 }
+
+char *add_bearer(char *uuid)
+{
+    char *bearer = malloc(sizeof(char) * (strlen(uuid) + 8));
+
+    if (bearer == NULL)
+        return NULL;
+    strcpy(bearer, "Bearer ");
+    strcat(bearer, uuid);
+    return bearer;
+}


### PR DESCRIPTION
I added the following functions :
- subscribe : subscribe to the events of a team and its sub directories
- subscribed : list all subscribed teams or list all users subscribed to a team (depending on the number of arguments)
- unsubscribe : unsubscribe from a team

Issue solved :
- close #16 
- close #17 
- close #18  