### PR TITLE
:sparkles: Add handling event for the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 ### VisualStudioCode template
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
 .history/

--- a/client/Makefile
+++ b/client/Makefile
@@ -29,6 +29,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/create/create_thread.c 				\
 					src/commands/create/create_reply.c 					\
 					src/commands/events/events.c 						\
+					src/commands/events/logged_in.c 					\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -31,6 +31,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/events/events.c 						\
 					src/commands/events/logged_in.c 					\
 					src/commands/events/logged_out.c 					\
+					src/commands/events/dm_received.c 					\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -28,6 +28,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/create/create_channel.c 				\
 					src/commands/create/create_thread.c 				\
 					src/commands/create/create_reply.c 					\
+					src/commands/events/events.c 						\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -35,6 +35,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/events/team_created.c 					\
 					src/commands/events/channel_created.c 				\
 					src/commands/events/thread_created.c 				\
+					src/commands/events/thread_replied.c 				\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -32,6 +32,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/events/logged_in.c 					\
 					src/commands/events/logged_out.c 					\
 					src/commands/events/dm_received.c 					\
+					src/commands/events/team_created.c 					\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -30,6 +30,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/create/create_reply.c 					\
 					src/commands/events/events.c 						\
 					src/commands/events/logged_in.c 					\
+					src/commands/events/logged_out.c 					\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -33,6 +33,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/events/logged_out.c 					\
 					src/commands/events/dm_received.c 					\
 					src/commands/events/team_created.c 					\
+					src/commands/events/channel_created.c 				\
 					src/utils/utils.c 									\
 
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -34,6 +34,7 @@ SOURCES			= 	src/main.c											\
 					src/commands/events/dm_received.c 					\
 					src/commands/events/team_created.c 					\
 					src/commands/events/channel_created.c 				\
+					src/commands/events/thread_created.c 				\
 					src/utils/utils.c 									\
 
 

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -96,3 +96,4 @@ void create_reply(char **parsed_cmd, client_t *client);
 
 void send_events(client_t *client);
 void logged_in_callback(json_object_t *data, client_t *client);
+void logged_out_callback(json_object_t *data, client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -101,3 +101,4 @@ void dm_received_callback(json_object_t *data, client_t *client);
 void team_created_callback(json_object_t *data, client_t *client);
 void channel_created_callback(json_object_t *data, client_t *client);
 void thread_created_callback(json_object_t *data, client_t *client);
+void thread_replied_callback(json_object_t *data, client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -97,3 +97,4 @@ void create_reply(char **parsed_cmd, client_t *client);
 void send_events(client_t *client);
 void logged_in_callback(json_object_t *data, client_t *client);
 void logged_out_callback(json_object_t *data, client_t *client);
+void dm_received_callback(json_object_t *data, client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -19,6 +19,7 @@
 #include "uuid/uuid.h"
 #include "network/api_client.h"
 #include "network/dto.h"
+#include "json/json.h"
 
 #define _GNU_SOURCE
 
@@ -26,6 +27,17 @@
 #define MAX_NAME_LENGTH 32
 #define MAX_DESCRIPTION_LENGTH 255
 #define MAX_BODY_LENGTH 512
+
+enum client_event {
+    LOGGED_IN,
+    LOGGED_OUT,
+    DM_RECEIVED,
+    TEAM_CREATED,
+    CHANNEL_CREATED,
+    THREAD_CREATED,
+    THREAD_REPLIED,
+    NONE,
+};
 
 typedef struct context_s {
     char const *team_uuid;
@@ -39,8 +51,18 @@ typedef struct client_s {
     char const *user_name;
     bool is_logged;
     bool waiting_for_response;
+    bool running;
+    bool is_event;
+    char *buffer;
     api_client_t *api_handler;
 } client_t;
+
+typedef struct event_bindig_s {
+    enum client_event event;
+    void (*callback)(json_object_t *data, client_t *client);
+} event_binding_t;
+
+extern const event_binding_t event_bindings[];
 
 int client(int ac, char **av);
 
@@ -52,7 +74,7 @@ char **parse_command(char *cmd);
 
 size_t tab_len(char **tab);
 char *add_bearer(const char *uuid);
-
+void logout_when_leaving(client_t *client);
 
 void help(char **parsed_cmd);
 void logout(char **parsed_cmd, client_t *client);
@@ -71,3 +93,5 @@ void create_team(char **parsed_cmd, client_t *client);
 void create_channel(char **parsed_cmd, client_t *client);
 void create_thread(char **parsed_cmd, client_t *client);
 void create_reply(char **parsed_cmd, client_t *client);
+
+void send_events(client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -95,3 +95,4 @@ void create_thread(char **parsed_cmd, client_t *client);
 void create_reply(char **parsed_cmd, client_t *client);
 
 void send_events(client_t *client);
+void logged_in_callback(json_object_t *data, client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -99,3 +99,4 @@ void logged_in_callback(json_object_t *data, client_t *client);
 void logged_out_callback(json_object_t *data, client_t *client);
 void dm_received_callback(json_object_t *data, client_t *client);
 void team_created_callback(json_object_t *data, client_t *client);
+void channel_created_callback(json_object_t *data, client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -98,3 +98,4 @@ void send_events(client_t *client);
 void logged_in_callback(json_object_t *data, client_t *client);
 void logged_out_callback(json_object_t *data, client_t *client);
 void dm_received_callback(json_object_t *data, client_t *client);
+void team_created_callback(json_object_t *data, client_t *client);

--- a/client/include/myclient.h
+++ b/client/include/myclient.h
@@ -100,3 +100,4 @@ void logged_out_callback(json_object_t *data, client_t *client);
 void dm_received_callback(json_object_t *data, client_t *client);
 void team_created_callback(json_object_t *data, client_t *client);
 void channel_created_callback(json_object_t *data, client_t *client);
+void thread_created_callback(json_object_t *data, client_t *client);

--- a/client/src/commands/create/create_team.c
+++ b/client/src/commands/create/create_team.c
@@ -25,7 +25,8 @@ void create_team_response_success(response_t *response,
     if (jobj_resp == NULL || jobj_send == NULL || team_uuid == NULL ||
         team_name == NULL || team_desc == NULL)
         return;
-    client_print_team(team_uuid->value, team_name->value, team_desc->value);
+    client_print_team_created(team_uuid->value, team_name->value,
+        team_desc->value);
 }
 
 void create_team_response(response_t *response, request_data_t *request_data)

--- a/client/src/commands/create/create_thread.c
+++ b/client/src/commands/create/create_thread.c
@@ -67,8 +67,8 @@ void create_thread_response(response_t *response, request_data_t *request_data)
     }
 }
 
-static json_object_t *create_thread_json(char *team_uuid, char *chan_uuid,
-    char *title, char *body)
+static json_object_t *create_thread_json(const char *team_uuid,
+    const char *chan_uuid, const char *title, const char *body)
 {
     json_object_t *jobj = json_object_create("root");
     json_string_t *team_uuid_json = json_string_create("team_uuid", team_uuid);

--- a/client/src/commands/events/channel_created.c
+++ b/client/src/commands/events/channel_created.c
@@ -1,0 +1,24 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** channel_created
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+
+void channel_created_callback(json_object_t *data, client_t *client)
+{
+    json_string_t *channel_uuid =
+        (json_string_t *)json_object_get(data, "channel_uuid");
+    json_string_t *channel_name =
+        (json_string_t *)json_object_get(data, "name");
+    json_string_t *channel_desc =
+        (json_string_t *)json_object_get(data, "description");
+
+    if (channel_uuid == NULL || channel_name == NULL || channel_desc == NULL)
+        return;
+    client_event_channel_created(channel_uuid->value, channel_name->value,
+        channel_desc->value);
+}

--- a/client/src/commands/events/dm_received.c
+++ b/client/src/commands/events/dm_received.c
@@ -1,0 +1,25 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** dm_received
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+
+void dm_received_callback(json_object_t *data, client_t *client)
+{
+    json_string_t *sender_uuid =
+        (json_string_t *)json_object_get(data, "sender_uuid");
+    json_object_t *message =
+        (json_string_t *)json_object_get(data, "message");
+    json_string_t *content = NULL;
+
+    if (sender_uuid == NULL || message == NULL)
+        return;
+    content = (json_string_t *)json_object_get(message, "content");
+    if (content == NULL)
+        return;
+    client_event_private_message_received(sender_uuid->value, content->value);
+}

--- a/client/src/commands/events/events.c
+++ b/client/src/commands/events/events.c
@@ -1,0 +1,81 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** events
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+
+const event_binding_t event_bindings[] = {
+    {LOGGED_IN, &logged_in_callback},
+    {LOGGED_OUT, &logged_out_callback},
+    {DM_RECEIVED, &dm_received_callback},
+    {TEAM_CREATED, &team_created_callback},
+    {CHANNEL_CREATED, &channel_created_callback},
+    {THREAD_CREATED, &thread_created_callback},
+    {THREAD_REPLIED, &thread_replied_callback},
+    {NONE, NULL}
+};
+
+static void handle_events_callback(json_object_t *data,
+    enum client_event event, client_t *client)
+{
+    for (size_t i = 0; event_bindings[i].event != NONE; i++) {
+        if (event_bindings[i].event == event) {
+            event_bindings[i].callback(data, client);
+            break;
+        }
+    }
+}
+
+static void handle_events(json_array_t *arr, client_t *client)
+{
+    json_object_t *event = NULL;
+    json_number_t *type = NULL;
+    json_object_t *data = NULL;
+
+    for (size_t i = 0; i < arr->size; i++) {
+        event = (json_object_t *)json_array_get(arr, i);
+        if (event == NULL)
+            return;
+        type = (json_number_t *)json_object_get(event, "type");
+        data = (json_object_t *)json_object_get(event, "data");
+        if (type == NULL || data == NULL)
+            return;
+        handle_events_callback(data, type->value, client);
+    }
+}
+
+void events_response(response_t *response, request_data_t *request_data)
+{
+    client_t *cli = (client_t *)request_data->data;
+    json_array_t *arr = NULL;
+
+    if (response->status == 200) {
+        arr = (json_array_t *)json_parse(response->body);
+        if (arr == NULL || arr->size == 0)
+            return;
+        handle_events(arr, cli);
+    }
+    cli->is_event = false;
+}
+
+void send_events(client_t *client)
+{
+    char *bearer = NULL;
+    request_t *request = calloc(1, sizeof(request_t));
+
+    if (request == NULL)
+        return;
+    request->route = (route_t){"GET", "/events"};
+    request->body = strdup("");
+    if (client->user_uuid != NULL) {
+        bearer = add_bearer(client->user_uuid);
+        if (bearer != NULL)
+            request_add_header(request, "Authorization", bearer);
+    }
+    api_client_send_request(client->api_handler, request, &events_response,
+        client);
+}

--- a/client/src/commands/events/logged_in.c
+++ b/client/src/commands/events/logged_in.c
@@ -1,0 +1,21 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** *
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+
+void logged_in_callback(json_object_t *data, client_t *client)
+{
+    json_string_t *user_uuid =
+        (json_string_t *)json_object_get(data, "user_uuid");
+    json_string_t *username =
+        (json_string_t *)json_object_get(data, "username");
+
+    if (user_uuid == NULL || username == NULL)
+        return;
+    client_event_logged_in(user_uuid->value, username->value);
+}

--- a/client/src/commands/events/logged_out.c
+++ b/client/src/commands/events/logged_out.c
@@ -1,0 +1,26 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** logged_out
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+
+void logged_out_callback(json_object_t *data, client_t *client)
+{
+    json_string_t *user_uuid =
+        (json_string_t *)json_object_get(data, "user_uuid");
+    json_string_t *username =
+        (json_string_t *)json_object_get(data, "username");
+
+    if (user_uuid == NULL || username == NULL)
+        return;
+    client_event_logged_out(user_uuid->value, username->value);
+    if (strcmp(user_uuid->value, client->user_uuid) == 0) {
+        client->is_logged = false;
+        client->user_uuid = NULL;
+        client->user_name = NULL;
+    }
+}

--- a/client/src/commands/events/team_created.c
+++ b/client/src/commands/events/team_created.c
@@ -1,0 +1,24 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** team_created
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+
+void team_created_callback(json_object_t *data, client_t *client)
+{
+    json_string_t *team_uuid =
+        (json_string_t *)json_object_get(data, "team_uuid");
+    json_string_t *team_name =
+        (json_string_t *)json_object_get(data, "name");
+    json_string_t *team_desc =
+        (json_string_t *)json_object_get(data, "description");
+
+    if (team_uuid == NULL || team_name == NULL || team_desc == NULL)
+        return;
+    client_event_team_created(team_uuid->value, team_name->value,
+        team_desc->value);
+}

--- a/client/src/commands/events/thread_created.c
+++ b/client/src/commands/events/thread_created.c
@@ -1,0 +1,29 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** *
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+
+void thread_created_callback(json_object_t *data, client_t *client)
+{
+    json_string_t *thread_uuid =
+        (json_string_t *)json_object_get(data, "thread_uuid");
+    json_string_t *user_uuid =
+        (json_string_t *)json_object_get(data, "sender_uuid");
+    json_string_t *title =
+        (json_string_t *)json_object_get(data, "title");
+    json_string_t *content =
+        (json_string_t *)json_object_get(data, "content");
+    json_number_t *timestamp =
+        (json_number_t *)json_object_get(data, "timestamp");
+
+    if (thread_uuid == NULL || user_uuid == NULL || title == NULL ||
+        content == NULL || timestamp == NULL)
+        return;
+    client_event_thread_created(thread_uuid->value, user_uuid->value,
+        timestamp->value, title->value, content->value);
+}

--- a/client/src/commands/events/thread_replied.c
+++ b/client/src/commands/events/thread_replied.c
@@ -1,0 +1,30 @@
+/*
+** EPITECH PROJECT, 2024
+** MyTeams
+** File description:
+** thread_replied
+*/
+
+#include "myclient.h"
+#include "logging_client.h"
+
+void thread_replied_callback(json_object_t *data, client_t *client)
+{
+    json_string_t *team_uuid =
+        (json_string_t *)json_object_get(data, "team_uuid");
+    json_string_t *thread_uuid =
+        (json_string_t *)json_object_get(data, "thread_uuid");
+    json_string_t *replier_uuid =
+        (json_string_t *)json_object_get(data, "sender_uuid");
+    json_object_t *message = (json_object_t *)json_object_get(data, "message");
+    json_string_t *content = NULL;
+
+    if (team_uuid == NULL || thread_uuid == NULL || replier_uuid == NULL
+        || message == NULL)
+        return;
+    content = (json_string_t *)json_object_get(message, "content");
+    if (content == NULL)
+        return;
+    client_event_thread_reply_received(team_uuid->value, thread_uuid->value,
+        replier_uuid->value, content->value);
+}

--- a/client/src/commands/logout.c
+++ b/client/src/commands/logout.c
@@ -16,8 +16,6 @@ void logout_rep(response_t *response, request_data_t *request_data)
     cli->waiting_for_response = false;
     if (response->status == 204) {
         cli->is_logged = false;
-        cli->user_uuid = NULL;
-        cli->user_name = NULL;
         printf("CLI : Successfully logged out\n");
     }
 }
@@ -50,5 +48,12 @@ void logout(char **parsed_cmd, client_t *client)
         printf("You are not logged in\n");
         return;
     }
+    request_logout(client);
+}
+
+void logout_when_leaving(client_t *client)
+{
+    if (client->is_logged == false)
+        return;
     request_logout(client);
 }

--- a/common/json/src/json.c
+++ b/common/json/src/json.c
@@ -9,6 +9,7 @@
 #include "json/json.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 static bool should_toggle_string(const char *content, size_t i)
 {
@@ -75,9 +76,7 @@ static void json_split_consumer(const char *content, size_t *count,
     split_t *tmp = NULL;
     size_t end = find_end(content, (*i));
 
-    if (end == *i + 1) {
-        (*i)++;
-    } else if (content[(*i)] == ':') {
+    if (content[(*i)] == ':') {
         tmp = malloc(sizeof(split_t));
         tmp->value = get_json_value(content + (*i) + 1);
         tmp->key = get_json_key(content, (*i));

--- a/common/json/src/json_object.c
+++ b/common/json/src/json_object.c
@@ -10,6 +10,7 @@
 #include "json/json.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 json_object_t *json_object_create(const char *key)
 {

--- a/tests/json/json_parser.c
+++ b/tests/json/json_parser.c
@@ -331,3 +331,54 @@ Test(json, safety_checks)
     free(obj);
     cr_assert(true);
 }
+
+Test(json_parser, json_parse_array_of_objects_with_int)
+{
+
+    FILE *file = fopen("../../tests/json/json_parse_array_of_objects_with_int.json", "wr");
+    char *str = "[\n"
+                "    {\n"
+                "        \"type\": 0,\n"
+                "        \"data\": {\n"
+                "            \"user_uuid\": \"e2dec3ccddd9c67f1c0135e1f294eab2\",\n"
+                "            \"username\": \"marius\"\n"
+                "        }\n"
+                "    }\n"
+                "]";
+    fwrite(str, 1, strlen(str), file);
+    fclose(file);
+
+    json_array_t *json = (json_array_t *) json_load_from_file("../../tests/json/json_parse_array_of_objects_with_int.json");
+
+    cr_assert(json->base.type == JSON_OBJECT_TYPE_ARRAY);
+    cr_assert_eq(json->size, 1);
+
+    json_object_t *obj = (json_object_t *) json_array_get(json, 0);
+    cr_assert(obj != NULL);
+    cr_assert(obj->base.type == JSON_OBJECT_TYPE_OBJECT);
+    cr_assert(obj->size == 2);
+
+    json_number_t *type = (json_number_t *) json_object_get(obj, "type");
+    cr_assert(type != NULL);
+    cr_assert(type->base.type == JSON_OBJECT_TYPE_NUMBER);
+    cr_assert_eq(type->value, 0);
+
+    json_object_t *data = (json_object_t *) json_object_get(obj, "data");
+    cr_assert(data != NULL);
+    cr_assert(data->base.type == JSON_OBJECT_TYPE_OBJECT);
+    cr_assert(data->size == 2);
+
+    json_string_t *user_uuid = (json_string_t *) json_object_get(data, "user_uuid");
+    cr_assert(user_uuid != NULL);
+    cr_assert(user_uuid->base.type == JSON_OBJECT_TYPE_STRING);
+    cr_assert_str_eq(user_uuid->value, "e2dec3ccddd9c67f1c0135e1f294eab2");
+
+    json_string_t *username = (json_string_t *) json_object_get(data, "username");
+    cr_assert(username != NULL);
+    cr_assert(username->base.type == JSON_OBJECT_TYPE_STRING);
+    cr_assert_str_eq(username->value, "marius");
+
+    json_destroy((json_t *) json);
+    free(json);
+    remove("../../tests/json/json_parse_array_of_objects_with_int.json");
+}


### PR DESCRIPTION
I added the handling of these event :
- client_event_logged_in : Will be called when a user successfully login to the server (/login)
- client_event_logged_out : Will be called when a user logged out (/logout or lost connexion)
- client_event_private_message_received : Will be called when the current logged user receives a private message
- client_event_thread_reply_received : Will be called when a new reply is posted in a thread
- client_event_team_created : Will be called when a new team is created
- client_event_channel_created : Will be called when a channel is created inside of a team
- client_event_thread_created : Will be called when a thread is created inside of a channel

Issue linked :
- #57 